### PR TITLE
MRI-4197 Removed a check that entry name is a substring of a long name as it's not present in the original util

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -566,24 +566,10 @@ namespace ICSharpCode.SharpZipLib.Tar
 					{
 						currentEntry = new TarEntry(headerBuf, encoding);
 						if (longName != null)
-						{
-							var longNameStr = longName.ToString();
-							
-							if (longNameStr.StartsWith(currentEntry.Name ?? string.Empty))
-								currentEntry.Name = longNameStr;
-							else
-								throw new InvalidHeaderException("The entry name is not a prefix of the long name");
-						}
+							currentEntry.TarHeader.Name = longName.ToString();
 
 						if (longLink != null)
-						{
-							var longLinkStr = longLink.ToString();
-							
-							if (longLinkStr.StartsWith(currentEntry.TarHeader.LinkName ?? string.Empty))
-								currentEntry.TarHeader.LinkName = longLinkStr;
-							else
-								throw new InvalidHeaderException("The entry link name is not a prefix of the long link");
-						}
+							currentEntry.TarHeader.LinkName = longLink.ToString();
 					}
 					else
 					{

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
@@ -211,14 +211,14 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			{
 				TarEntry nextEntry = tarIn.GetNextEntry();
 
-				Assert.AreEqual(nextEntry.Name, name, "Name match failure");
+				Assert.AreEqual(name, nextEntry.Name, "Name match failure");
 			}
 		}
 		
 		private void TryLongLink(string name, string linkName)
 		{
 			var ms = new MemoryStream();
-			using (TarOutputStream tarOut = new TarOutputStream(ms, null))
+			using (TarOutputStream tarOut = new TarOutputStream(ms, Encoding.UTF8))
 			{
 				DateTime modTime = DateTime.Now;
 
@@ -231,12 +231,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			ms2.Write(ms.GetBuffer(), 0, ms.GetBuffer().Length);
 			ms2.Seek(0, SeekOrigin.Begin);
 
-			using (TarInputStream tarIn = new TarInputStream(ms2, null))
+			using (TarInputStream tarIn = new TarInputStream(ms2, Encoding.UTF8))
 			{
 				TarEntry nextEntry = tarIn.GetNextEntry();
 
-				Assert.AreEqual(nextEntry.Name, name, "Name match failure");
-				Assert.AreEqual(nextEntry.TarHeader.LinkName, linkName, "Link name match failure");
+				Assert.AreEqual(name, nextEntry.Name, "Name match failure");
+				Assert.AreEqual(linkName, nextEntry.TarHeader.LinkName, "Link name match failure");
 			}
 		}
 
@@ -288,9 +288,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 		[Category("Tar")]
 		public void LongLinks()
 		{
+			TryLongLink("/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя",
+				"/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя");
+			
 			TryLongLink("short_name",
 				"11111111112222222222333333333344444444445555555555" +
-			            "6666666666777777777788888888889999999999000000000");
+				"6666666666777777777788888888889999999999000000000");
 
 			TryLongLink("11111111112222222222333333333344444444445555555555" +
 			            "66666666667777777777888888888899999999990000000000",


### PR DESCRIPTION
Removed a check that entry name is a substring of a long name as it's not present in the original util.

Added multi-byte encoding test in which tar entry name is trimmed in between a multi-byte character.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
